### PR TITLE
feat: add meeting SP tracking for team reporting and productivity sum…

### DIFF
--- a/apps/tere-project/src/features/dashboard/types/dashboard.ts
+++ b/apps/tere-project/src/features/dashboard/types/dashboard.ts
@@ -13,6 +13,8 @@ export interface WorkItem {
   wpToHours?: number;
   spProduct?: number;
   spTechDebt?: number;
+  /** Direct Story Points from meeting tickets (ALL-Meeting prefix). Not converted via WP. */
+  spMeeting?: number;
   spTotal?: number;
   plannedWP?: number;
 }

--- a/apps/tere-project/src/server/modules/reports/productivity-summary.service.ts
+++ b/apps/tere-project/src/server/modules/reports/productivity-summary.service.ts
@@ -13,6 +13,8 @@ export interface ProductivitySummaryMemberDto {
   expectedAverageWp: number;
   spProduct: number;
   spTechDebt: number;
+  /** Direct Story Points from meeting tickets (ALL-Meeting prefix). Not converted via WP. */
+  spMeeting: number;
   spTotal: number;
 }
 
@@ -67,8 +69,10 @@ export async function generateProductivitySummary(month: number, year: number, t
       const spBase = targetWp > 0 ? (8 * workingDays) / targetWp : 0;
       const spProduct = wpProduct * spBase;
       const spTechDebt = wpTech * spBase;
-      const spTotal = spProduct + spTechDebt;
-      details.push({ name: displayName, team: entry.shortName, wpProduct, wpTech, wpTotal, workingDays, averageWp, expectedAverageWp, spProduct, spTechDebt, spTotal });
+      // spMeeting comes directly from meeting tickets — already computed in reports.service
+      const spMeeting = issue.spMeeting ?? 0;
+      const spTotal = spProduct + spTechDebt + spMeeting;
+      details.push({ name: displayName, team: entry.shortName, wpProduct, wpTech, wpTotal, workingDays, averageWp, expectedAverageWp, spProduct, spTechDebt, spMeeting, spTotal });
     }
   }
   details.sort((a, b) => a.name.localeCompare(b.name));
@@ -108,8 +112,8 @@ export async function exportProductivitySummaryToSpreadsheet(month: number, year
     ['Productivity Produced', safeNumber(data.summary.productivityProduced)],
     ['Produce vs Expected', `${(data.summary.productivityProduceVsExpected * 100).toFixed(2)}%`],
     [],
-    ['Name', 'Team', 'SP Product', 'SP Tech Debt', 'SP Total', 'Working Days', 'WP Product', 'WP Tech', 'WP Total', 'Avg WP / Day', 'Expected Avg WP'],
-    ...data.details.map((m) => [m.name, m.team, Number(m.spProduct.toFixed(2)) || 0, Number(m.spTechDebt.toFixed(2)) || 0, Number(m.spTotal.toFixed(2)) || 0, m.workingDays, m.wpProduct, m.wpTech, Number(m.wpTotal.toFixed(2)) || 0, Number(m.averageWp.toFixed(2)) || 0, Number(m.expectedAverageWp.toFixed(2)) || 0]),
+    ['Name', 'Team', 'SP Product', 'SP Tech Debt', 'SP Meeting', 'SP Total', 'Working Days', 'WP Product', 'WP Tech', 'WP Total', 'Avg WP / Day', 'Expected Avg WP'],
+    ...data.details.map((m) => [m.name, m.team, Number(m.spProduct.toFixed(2)) || 0, Number(m.spTechDebt.toFixed(2)) || 0, m.spMeeting, Number(m.spTotal.toFixed(2)) || 0, m.workingDays, m.wpProduct, m.wpTech, Number(m.wpTotal.toFixed(2)) || 0, Number(m.averageWp.toFixed(2)) || 0, Number(m.expectedAverageWp.toFixed(2)) || 0]),
   ];
 
   const requests: any[] = [
@@ -117,11 +121,11 @@ export async function exportProductivitySummaryToSpreadsheet(month: number, year
     { repeatCell: { range: { sheetId: 0, startRowIndex: 0, endRowIndex: 1, startColumnIndex: 0, endColumnIndex: 2 }, cell: { userEnteredFormat: { backgroundColor: { red: 0.4, green: 0.3, blue: 0.7 }, textFormat: { foregroundColor: { red: 1, green: 1, blue: 1 }, bold: true, fontSize: 14 }, horizontalAlignment: 'CENTER' } }, fields: 'userEnteredFormat(backgroundColor,textFormat,horizontalAlignment)' } },
     { mergeCells: { range: { sheetId: 0, startRowIndex: 0, endRowIndex: 1, startColumnIndex: 0, endColumnIndex: 2 }, mergeType: 'MERGE_ALL' } },
     { repeatCell: { range: { sheetId: 0, startRowIndex: 2, endRowIndex: 3, startColumnIndex: 0, endColumnIndex: 2 }, cell: { userEnteredFormat: { backgroundColor: { red: 0.9, green: 0.9, blue: 0.9 }, textFormat: { bold: true } } }, fields: 'userEnteredFormat(backgroundColor,textFormat)' } },
-    { repeatCell: { range: { sheetId: 0, startRowIndex: 12, endRowIndex: 13, startColumnIndex: 0, endColumnIndex: 11 }, cell: { userEnteredFormat: { backgroundColor: { red: 0.9, green: 0.9, blue: 0.9 }, textFormat: { bold: true }, horizontalAlignment: 'CENTER' } }, fields: 'userEnteredFormat(backgroundColor,textFormat,horizontalAlignment)' } },
+    { repeatCell: { range: { sheetId: 0, startRowIndex: 12, endRowIndex: 13, startColumnIndex: 0, endColumnIndex: 12 }, cell: { userEnteredFormat: { backgroundColor: { red: 0.9, green: 0.9, blue: 0.9 }, textFormat: { bold: true }, horizontalAlignment: 'CENTER' } }, fields: 'userEnteredFormat(backgroundColor,textFormat,horizontalAlignment)' } },
   ];
 
   const createResponse = await sheets.spreadsheets.create({
-    requestBody: { properties: { title }, sheets: [{ properties: { sheetId: 0, title: 'Summary', gridProperties: { rowCount: values.length + 10, columnCount: 10 } } }] },
+    requestBody: { properties: { title }, sheets: [{ properties: { sheetId: 0, title: 'Summary', gridProperties: { rowCount: values.length + 10, columnCount: 12 } } }] },
   });
 
   const spreadsheetId = createResponse.data.spreadsheetId!;

--- a/apps/tere-project/src/server/modules/reports/reports.service.ts
+++ b/apps/tere-project/src/server/modules/reports/reports.service.ts
@@ -4,6 +4,7 @@ import type {
 } from '@shared/types/report.types';
 import type { MemberResponse } from '@shared/types/member.types';
 import type { LeaveDateRange } from '@shared/types/talent-leave.types';
+import { isMeetingAppendixValue, parseMeetingSP } from '@shared/utils/appendix-level';
 import { membersService } from '@server/modules/members/members.service';
 import { issueProcessingStrategyFactory } from './strategies/issue-processing-strategy.factory';
 import { talentLeaveService } from '@server/modules/talent-leave/talent-leave.service';
@@ -75,6 +76,20 @@ function calculateDefectRate(defectCount: number): string {
   return '0%';
 }
 
+/**
+ * Extracts the total meeting SP from an issue's customfield_11543 options.
+ * Sums SP values from all "ALL-Meeting" prefixed entries.
+ */
+function extractMeetingSPFromIssue(issue: JiraIssueEntity): number {
+  const selectedOptions = issue.fields.customfield_11543 || [];
+  return selectedOptions.reduce((total: number, option: any) => {
+    const value = option?.value;
+    if (!value || !isMeetingAppendixValue(value)) return total;
+    const sp = parseMeetingSP(value);
+    return sp !== null ? total + sp : total;
+  }, 0);
+}
+
 function processRawData(
   rawData: JiraIssueEntity[],
   members: MemberResponse[],
@@ -94,7 +109,7 @@ function processRawData(
   const reports = new Map<string, JiraIssueReportResponseDto>(
     members.map((m) => [
       m.fullName,
-      { member: m.fullName, team: m.teams[0] ?? '', productivityRate: '', totalWeightPoints: 0, devDefect: 0, devDefectRate: '', level: m.level, weightPointsProduct: 0, weightPointsTechDebt: 0, targetWeightPoints: (dailyTargetWPByLevel[m.level] ?? 8) * 10, issueKeys: [] },
+      { member: m.fullName, team: m.teams[0] ?? '', productivityRate: '', totalWeightPoints: 0, devDefect: 0, devDefectRate: '', level: m.level, weightPointsProduct: 0, weightPointsTechDebt: 0, targetWeightPoints: (dailyTargetWPByLevel[m.level] ?? 8) * 10, issueKeys: [], spMeeting: 0 },
     ]),
   );
 
@@ -116,10 +131,18 @@ function processRawData(
       report.issueKeys.push(issue.key);
       const isDone = issue.fields.resolution?.name === 'Done';
       if (!isShowPlannedWP || isDone) {
-        report[weightPoints] += complexityWeight;
+        // Extract meeting SP from ALL-Meeting appendix options before adding WP
+        const meetingSP = extractMeetingSPFromIssue(issue);
+        if (meetingSP > 0) {
+          // Meeting tickets: accumulate direct SP, do not add to WP
+          report.spMeeting = (report.spMeeting ?? 0) + meetingSP;
+        } else {
+          // Regular tickets: accumulate weight points as usual
+          report[weightPoints] += complexityWeight;
+          const cData = complexityMap.get(memberName);
+          if (cData) { cData.totalComplexity += complexityWeight; cData.count++; }
+        }
         if (issue.fields.issuetype?.name === 'Bug') report.devDefect++;
-        const cData = complexityMap.get(memberName);
-        if (cData) { cData.totalComplexity += complexityWeight; cData.count++; }
       }
     } catch (error) { console.error('Error processing issue:', error); }
   });
@@ -143,11 +166,15 @@ function processRawData(
     const spBase = report.targetWeightPoints > 0 ? (8 * effectiveWorkingDays) / report.targetWeightPoints : 0;
     report.spProduct = report.weightPointsProduct * spBase;
     report.spTechDebt = report.weightPointsTechDebt * spBase;
-    report.spTotal = report.spProduct + report.spTechDebt;
+    // spMeeting is a direct SP value — not converted through WP/spBase
+    const spMeeting = report.spMeeting ?? 0;
+    report.spTotal = report.spProduct + report.spTechDebt + spMeeting;
     if (report.totalWeightPoints === 0) {
       report.weightPointsProduct = 0; report.weightPointsTechDebt = 0; report.devDefect = 0;
       report.devDefectRate = '0%'; report.productivityRate = '0%'; report.wpToHours = 0;
-      report.spProduct = 0; report.spTechDebt = 0; report.spTotal = 0;
+      report.spProduct = 0; report.spTechDebt = 0;
+      // spMeeting is preserved even when WP is zero — meeting tickets are independent of WP
+      report.spTotal = report.spMeeting ?? 0;
     }
   });
 

--- a/apps/tere-project/src/server/modules/reports/strategies/v3-complexity-weight.strategy.ts
+++ b/apps/tere-project/src/server/modules/reports/strategies/v3-complexity-weight.strategy.ts
@@ -1,6 +1,6 @@
 import type { IComplexityWeightStrategy } from './complexity-weight.strategy';
 import type { JiraIssueEntity } from '@shared/types/report.types';
-import { parseAppendixWeightPoints, type AppendixWeightPoint } from '@shared/utils/appendix-level';
+import { parseAppendixWeightPoints, isMeetingAppendixValue, parseMeetingSP, type AppendixWeightPoint } from '@shared/utils/appendix-level';
 import type { WpWeights } from '@server/modules/wp-weight-config/wp-weight-config.repository';
 
 const DEFAULT_WEIGHTS: WpWeights = {
@@ -13,14 +13,35 @@ const DEFAULT_WEIGHTS: WpWeights = {
 export class V3ComplexityWeightStrategy implements IComplexityWeightStrategy {
   constructor(private readonly weights: Record<AppendixWeightPoint, number> = DEFAULT_WEIGHTS) {}
 
+  /**
+   * Calculates the Weight Points (WP) for an issue.
+   * Meeting tickets (ALL-Meeting prefix) are excluded from WP calculation — they return 0.
+   */
   calculateWeight(issue: JiraIssueEntity): number {
     const selectedOptions = issue.fields.customfield_11543 || [];
     return selectedOptions.reduce((total: number, option: any) => {
       const appendixWeightText = option?.value;
       if (!appendixWeightText) return total;
+      // Meeting tickets are not counted as WP — skip them entirely
+      if (isMeetingAppendixValue(appendixWeightText)) return total;
       const weightPoint = parseAppendixWeightPoints(appendixWeightText);
       if (!weightPoint) return total;
       return total + this.weights[weightPoint];
+    }, 0);
+  }
+
+  /**
+   * Extracts the total Story Points from meeting appendix values.
+   * Only applies to options with "ALL-Meeting" prefix.
+   * Non-meeting options contribute 0 SP here — they are handled via WP conversion.
+   */
+  extractMeetingSP(issue: JiraIssueEntity): number {
+    const selectedOptions = issue.fields.customfield_11543 || [];
+    return selectedOptions.reduce((total: number, option: any) => {
+      const appendixWeightText = option?.value;
+      if (!appendixWeightText) return total;
+      const sp = parseMeetingSP(appendixWeightText);
+      return sp !== null ? total + sp : total;
     }, 0);
   }
 }

--- a/apps/tere-project/src/shared/types/report.types.ts
+++ b/apps/tere-project/src/shared/types/report.types.ts
@@ -109,6 +109,8 @@ export interface JiraIssueReportResponseDto {
   wpToHours?: number;
   spProduct?: number;
   spTechDebt?: number;
+  /** Direct Story Points from meeting tickets (ALL-Meeting prefix). Not converted via WP. */
+  spMeeting?: number;
   spTotal?: number;
   plannedWP?: number;
   epic?: EpicDto | null;

--- a/apps/tere-project/src/shared/utils/appendix-level.ts
+++ b/apps/tere-project/src/shared/utils/appendix-level.ts
@@ -4,3 +4,23 @@ export function parseAppendixWeightPoints(appendixText: string): AppendixWeightP
   const match = appendixText.match(/-(Very Low|Low|Medium|High)$/);
   return match ? (match[1] as AppendixWeightPoint) : null;
 }
+
+/**
+ * Checks whether a customfield_11543 option value is a meeting ticket.
+ * Meeting format: "ALL-Meeting {n}-No Complexity-{n}SP"
+ * Example: "ALL-Meeting 1-No Complexity-1SP"
+ */
+export function isMeetingAppendixValue(appendixText: string): boolean {
+  return appendixText.startsWith('ALL-Meeting');
+}
+
+/**
+ * Extracts the SP value from a meeting appendix string.
+ * Example: "ALL-Meeting 2-No Complexity-2SP" → 2
+ * Returns null if the format is not a valid meeting value.
+ */
+export function parseMeetingSP(appendixText: string): number | null {
+  if (!isMeetingAppendixValue(appendixText)) return null;
+  const match = appendixText.match(/-(\d+)SP$/);
+  return match ? parseInt(match[1], 10) : null;
+}


### PR DESCRIPTION
…mary

- Recognize new Appendix V3 format: ALL-Meeting {1-4}-No Complexity-{1-4}SP
- Add helper functions to detect and parse meeting SP values
- Separate meeting tickets from WP (weight points) calculation
- Add new spMeeting field to track SP directly from meeting tickets
- Update SP total formula: spTotal = spProduct + spTechDebt + spMeeting
- Update Team Reporting to exclude meeting from level-based WP conversion
- Update Productivity Summary to include spMeeting in calculations and exports
- Meeting SP is directly added without member level conversion
- Backward compatible with existing non-meeting ticket logic

This enables managers to track total working hours (actual work + meetings) against targets.