### PR TITLE
perf: optimize epic filter — client-side filtering, cache optimizatio…

### DIFF
--- a/apps/tere-project/src/app/dashboard/layout.tsx
+++ b/apps/tere-project/src/app/dashboard/layout.tsx
@@ -138,7 +138,16 @@ export default function DashboardLayout({
 }) {
   const { user, loading } = useUser();
   const router = useRouter();
-  const [queryClient] = useState(() => new QueryClient());
+  const [queryClient] = useState(() => new QueryClient({
+    defaultOptions: {
+      queries: {
+        // Keep data fresh for 5 minutes before background refetch
+        staleTime: 5 * 60 * 1000,
+        // Garbage collect unused query data after 10 minutes
+        gcTime: 10 * 60 * 1000,
+      },
+    },
+  }));
   const { pageBg, theme } = useThemeColors();
 
   const [animFinished, setAnimFinished] = useState(() => {

--- a/apps/tere-project/src/features/dashboard/components/epicSelect.tsx
+++ b/apps/tere-project/src/features/dashboard/components/epicSelect.tsx
@@ -42,13 +42,15 @@ export function EpicSelect({ isStoryGrouping = false }: { isStoryGrouping?: bool
   const setEpicFilter = useTeamReportFilterStore(state => state.setEpicFilter);
   const label = isStoryGrouping ? 'Story' : 'Epic';
 
-  // Fetch epics or stories based on board grouping type
+  // Fetch epics or stories based on board grouping type.
+  // staleTime: 5 min — epic list rarely changes mid-session, safe to cache aggressively.
   const { data: epics, isLoading } = useQuery({
     queryKey: [isStoryGrouping ? 'stories' : 'epics', sprint, startDate, endDate, project],
     queryFn: () => isStoryGrouping
       ? jiraRepository.fetchStories(sprint, project, startDate, endDate)
       : jiraRepository.fetchEpics(sprint, project, startDate, endDate),
     enabled: !!project && (!!sprint || (!!startDate && !!endDate)),
+    staleTime: 5 * 60 * 1000,
   });
 
   const handleChange = (value: string) => {
@@ -146,8 +148,9 @@ export function EpicSelect({ isStoryGrouping = false }: { isStoryGrouping?: bool
                 onClick={() => handleChange(option.value)}
                 title={option.title || option.label}
                 className={`
-                  flex-shrink-0 px-4 py-2 rounded-xl text-xs font-medium transition-all duration-300
+                  flex-shrink-0 px-4 py-2 rounded-xl text-xs font-medium transition-all duration-200 ease-out
                   border select-none whitespace-nowrap flex items-center gap-2
+                  active:scale-95
                   ${isActive
                     ? 'bg-blue-600 text-white border-blue-600 shadow-md shadow-blue-200 transform scale-105'
                     : 'bg-white text-gray-600 border-gray-200 hover:border-blue-300 hover:text-blue-600 hover:bg-blue-50'

--- a/apps/tere-project/src/features/dashboard/hooks/useTeamReportFetch.ts
+++ b/apps/tere-project/src/features/dashboard/hooks/useTeamReportFetch.ts
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { jiraRepository } from '@src/features/dashboard/repositories/jiraRepository';
 
 export function useTeamReportFetch() {
-  const { sprint, project, startDate, endDate, epicId } = useTeamReportFilterStore(
+  const { sprint, project, startDate, endDate } = useTeamReportFilterStore(
     state => state.selectedFilter,
   );
   const selectedTeams = useTeamReportFilterStore(state => state.selectedTeams);
@@ -15,14 +15,15 @@ export function useTeamReportFetch() {
   const hasValidFilter = hasSprintFilter || hasDateRangeFilter;
 
   return useQuery({
-    // Include both sprint and date range in queryKey for proper cache management
-    queryKey: ['teamReport', sprint, startDate, endDate, project, epicId, selectedTeams.sort().join(',')],
+    // epicId intentionally excluded from queryKey — epic filtering is now client-side via useMemo.
+    // Changing the epic selection does NOT trigger a new network request.
+    queryKey: ['teamReport', sprint, startDate, endDate, project, selectedTeams.sort().join(',')],
     queryFn: () => jiraRepository.fetchTeamReport(
-      sprint, 
-      project, 
-      startDate, 
+      sprint,
+      project,
+      startDate,
       endDate,
-      epicId ? (Array.isArray(epicId) ? epicId.join(',') : epicId) : undefined
+      // No epicId passed — server returns full unfiltered dataset; client filters via useTeamReportTransform
     ),
     enabled: hasValidFilter && !!project && selectedTeams.length > 0,
   });

--- a/apps/tere-project/src/features/dashboard/hooks/useTeamReportTransform.ts
+++ b/apps/tere-project/src/features/dashboard/hooks/useTeamReportTransform.ts
@@ -1,15 +1,39 @@
 import { useMemo } from 'react';
 import { useTeamReportFetch } from './useTeamReportFetch';
+import { useTeamReportFilterStore } from '@src/features/dashboard/store/teamReportFilterStore';
 import { DashhboardEntity } from '../types/dashboard';
 
 export const useTeamReportTransform = () => {
   const { data, isLoading, error } = useTeamReportFetch();
 
+  // Subscribe to epicId from Zustand store for client-side filtering.
+  // Changing epicId does NOT trigger a refetch — only a cheap useMemo recompute.
+  const epicId = useTeamReportFilterStore(state => state.selectedFilter.epicId);
+
   const dashboardData: DashhboardEntity | null = useMemo(() => {
     if (!data) return null;
 
+    let workItems = data.issues;
+
+    // Apply client-side epic filter when an epic selection is active.
+    // Uses the `epicKeys` field populated by the server on each WorkItem.
+    // 'null' (string) in epicId means "issues with no parent epic".
+    if (epicId && epicId.length > 0) {
+      workItems = workItems.filter(item => {
+        const memberEpicKeys = item.epicKeys ?? [];
+
+        // If filtering for 'null', include members who have issues with no parent epic
+        if (epicId.includes('null')) {
+          if (memberEpicKeys.includes('null')) return true;
+        }
+
+        // Include member if any of their epic keys match the selected epics
+        return epicId.some(selectedEpic => selectedEpic !== 'null' && memberEpicKeys.includes(selectedEpic));
+      });
+    }
+
     return {
-      workItems: data.issues,
+      workItems,
       totalWeightPointsProduct: data.totalWeightPointsProduct,
       totalWeightPointsTechDebt: data.totalWeightPointsTechDebt,
       productPercentage: data.productPercentage,
@@ -30,7 +54,7 @@ export const useTeamReportTransform = () => {
       sprintStartDate: data.sprintStartDate,
       sprintEndDate: data.sprintEndDate,
     };
-  }, [data]);
+  }, [data, epicId]);
 
   return {
     data: dashboardData,

--- a/apps/tere-project/src/features/dashboard/types/dashboard.ts
+++ b/apps/tere-project/src/features/dashboard/types/dashboard.ts
@@ -12,6 +12,12 @@ export interface WorkItem {
   weightPointsTechDebt: number;
   targetWeightPoints: number;
   issueKeys: string[];
+  /**
+   * Unique epic/parent keys associated with this member's issues.
+   * Used for client-side epic filtering without additional network requests.
+   * Populated by the server and included in every report response.
+   */
+  epicKeys?: string[];
   workingDays?: number;
   wpToHours?: number;
   spProduct?: number;

--- a/apps/tere-project/src/server/modules/reports/reports.service.ts
+++ b/apps/tere-project/src/server/modules/reports/reports.service.ts
@@ -200,6 +200,7 @@ function processRawData(
       weightPointsTechDebt: 0,
       targetWeightPoints: (dailyTargetWPByLevel[m.level] ?? 8) * 10,
       issueKeys: [],
+      epicKeys: [],
       spMeeting: 0,
     };
   }
@@ -250,6 +251,14 @@ function processRawData(
       const report = reports.get(reportKey);
       if (!report) return;
       report.issueKeys.push(issue.key);
+
+      // Track epic keys for client-side filtering; 'null' (string) means no parent epic
+      const epicKey = issue.fields.parent?.key ?? 'null';
+      if (!report.epicKeys) report.epicKeys = [];
+      if (!report.epicKeys.includes(epicKey)) {
+        report.epicKeys.push(epicKey);
+      }
+
       const isDone = issue.fields.resolution?.name === 'Done';
       if (!isShowPlannedWP || isDone) {
         // Extract meeting SP from ALL-Meeting appendix options before adding WP

--- a/apps/tere-project/src/shared/types/report.types.ts
+++ b/apps/tere-project/src/shared/types/report.types.ts
@@ -108,6 +108,12 @@ export interface JiraIssueReportResponseDto {
   weightPointsTechDebt: number;
   targetWeightPoints: number;
   issueKeys: string[];
+  /**
+   * Unique epic/parent keys associated with this member's issues.
+   * Populated during report generation for client-side epic filtering.
+   * Value 'null' (string) indicates issues with no parent epic.
+   */
+  epicKeys?: string[];
   workingDays?: number;
   wpToHours?: number;
   spProduct?: number;


### PR DESCRIPTION
…n, smooth animations

- Remove epicId from teamReport queryKey so epic toggle never fires a network request
- Populate epicKeys[] per WorkItem on server for client-side epic matching in useTeamReportTransform
- Apply epic filter via useMemo in useTeamReportTransform using cached DashboardDto
- Add QueryClient defaultOptions: staleTime 5m / gcTime 10m in dashboard layout
- Add staleTime 5m to epic list query in EpicSelect
- Upgrade chip animation: duration-300 → duration-200 ease-out, add active:scale-95